### PR TITLE
added mochiweb to applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule HtmlSanitizeEx.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :mochiweb]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
this only adds mochiweb to the applications list in mix.exs. exrm needs this to create releases. see https://exrm.readme.io/docs/common-issues
