### PR TITLE
use parentheses to remove ambiguity in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule HtmlSanitizeEx.Mixfile do
       ],
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps
+      deps: deps()
     ]
   end
 


### PR DESCRIPTION
Got this warning

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /my_app/deps/html_sanitize_ex/mix.exs:20
```