### PR TITLE
Update 'mochiweb' to 2.15

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule HtmlSanitizeEx.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:mochiweb, "~> 2.12.2"},
+      {:mochiweb, "~> 2.15"},
       {:inch_ex, ">= 0.0.0", only: :docs}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"inch_ex": {:hex, :inch_ex, "0.5.1", "c1c18966c935944cbb2d273796b36e44fab3c54fd59f906ff026a686205b4e14", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
-  "mochiweb": {:hex, :mochiweb, "2.12.2", "80804ad342afa3d7f3524040d4eed66ce74b17a555de454ac85b07c479928e46", [:make, :rebar], []},
+  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []}}


### PR DESCRIPTION
- Upgrade to the latest release of [`mochiweb`](https://hex.pm/packages/mochiweb/2.15.0).

I need to make this change because we'd like to use `html_sanitize_ex` and `floki` in the [same project](https://github.com/dailydrip/firestorm/pull/48), but there's a version conflict. `floki` requires `mochiweb` to be at least `2.15.0`.