### PR TITLE
Add caption and div tags to HTML5 whitelist

### DIFF
--- a/lib/html_sanitize_ex/scrubber/html5.ex
+++ b/lib/html_sanitize_ex/scrubber/html5.ex
@@ -41,6 +41,7 @@ defmodule HtmlSanitizeEx.Scrubber.HTML5 do
 
   Meta.allow_tag_with_these_attributes "code", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "spellcheck", "tabindex", "title", "translate"]
   Meta.allow_tag_with_these_attributes "del", ["accesskey", "cite", "datetime", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "spellcheck", "tabindex", "title", "translate"]
+  Meta.allow_tag_with_these_attributes "div", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "inert", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "role", "spellcheck", "tabindex", "title", "translate"]
   Meta.allow_tag_with_these_attributes "em", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "spellcheck", "tabindex", "title", "translate"]
 
   Meta.allow_tag_with_these_attributes "h1", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "inert", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "role", "spellcheck", "tabindex", "title", "translate"]

--- a/lib/html_sanitize_ex/scrubber/html5.ex
+++ b/lib/html_sanitize_ex/scrubber/html5.ex
@@ -37,6 +37,7 @@ defmodule HtmlSanitizeEx.Scrubber.HTML5 do
 
   Meta.allow_tag_with_these_attributes "blockquote", ["accesskey", "cite", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "spellcheck", "tabindex", "title", "translate"]
   Meta.allow_tag_with_these_attributes "br", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "spellcheck",   "tabindex", "title", "translate"]
+  Meta.allow_tag_with_these_attributes "caption", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "inert", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "role", "spellcheck", "tabindex", "title", "translate"]
 
   Meta.allow_tag_with_these_attributes "code", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "spellcheck", "tabindex", "title", "translate"]
   Meta.allow_tag_with_these_attributes "del", ["accesskey", "cite", "datetime", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "spellcheck", "tabindex", "title", "translate"]

--- a/test/html5_test.exs
+++ b/test/html5_test.exs
@@ -54,4 +54,10 @@ defmodule HtmlSanitizeExScrubberHTML5Test do
     expected = "<table><caption>This is a table</caption><thead></thead><tbody></tbody></table>"
     assert expected == full_html_sanitize(input)
   end
+
+  test "does not strip divs" do
+    input = ~s(<div class="a"><div class="b">Hello</div></div>)
+    expected = ~s(<div class="a"><div class="b">Hello</div></div>)
+    assert expected == full_html_sanitize(input)
+  end
 end

--- a/test/html5_test.exs
+++ b/test/html5_test.exs
@@ -43,11 +43,15 @@ defmodule HtmlSanitizeExScrubberHTML5Test do
     assert expected == full_html_sanitize(input)
   end
 
-
-
   test "strips everything except the allowed tags (for multiple tags)" do
     input = "<section><header><script>code!</script></header><p>hello <script>code!</script></p></section>"
     expected = "<section><header>code!</header><p>hello code!</p></section>"
+    assert expected == full_html_sanitize(input)
+  end
+
+  test "does not strip caption from tables" do
+    input = "<table><caption>This is a table</caption><thead></thead><tbody></tbody></table>"
+    expected = "<table><caption>This is a table</caption><thead></thead><tbody></tbody></table>"
     assert expected == full_html_sanitize(input)
   end
 end


### PR DESCRIPTION
In my use of `HtmlSanitizeEx` the fact that `<div>` and `<caption>` got scrubbed was an issue. This PR adds them to the whitelist, since it seems to me that they should be present if the other table tags and other block tags like `<p>` or `<section>` are. Are there ways they are uniquely susceptible to malicious content, and hence were intentionally not included?