### PR TITLE
Add the URI scheme 'mailto' to the HTML5 whitelist

### DIFF
--- a/lib/html_sanitize_ex/scrubber/html5.ex
+++ b/lib/html_sanitize_ex/scrubber/html5.ex
@@ -27,7 +27,7 @@ defmodule HtmlSanitizeEx.Scrubber.HTML5 do
 
   Meta.strip_comments
 
-  @valid_schemes ["http", "https"]
+  @valid_schemes ["http", "https", "mailto"]
 
   Meta.allow_tag_with_uri_attributes   "a", ["href"], @valid_schemes
   Meta.allow_tag_with_these_attributes "a", ["accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "inert", "itemid", "itemprop", "itemref", "itemscope", "itemtype", "lang", "role", "spellcheck", "tabindex", "title", "translate",

--- a/test/html5_test.exs
+++ b/test/html5_test.exs
@@ -60,4 +60,10 @@ defmodule HtmlSanitizeExScrubberHTML5Test do
     expected = ~s(<div class="a"><div class="b">Hello</div></div>)
     assert expected == full_html_sanitize(input)
   end
+
+  test "does not strip the mailto URI scheme" do
+    input = ~s(<a href="mailto:someone@yoursite.com">Email Us</a>)
+    expected = ~s(<a href="mailto:someone@yoursite.com">Email Us</a>)
+    assert expected == full_html_sanitize(input)
+  end
 end


### PR DESCRIPTION
Why:
The URI scheme 'mailto' is currently being removed when calling `HtmlSanitizeEx.html5/1`. Example: 
```
HtmlSanitizeEx.html5("<a href=\"mailto:someone@yoursite.com\">Email Us</a>")
iex > "<a>Email Us</a>"
```

This PR:
Allows the 'mailto' URI scheme to remain intact when using the HTML5
scrubber.