### PR TITLE
fixing case matching clause error on invalid schema URI formattings

### DIFF
--- a/lib/html_sanitize_ex/scrubber/meta.ex
+++ b/lib/html_sanitize_ex/scrubber/meta.ex
@@ -184,15 +184,24 @@ defmodule HtmlSanitizeEx.Scrubber.Meta do
         nil
       end
 
-      @protocol_separator ~r/:|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/mi
-      @scheme_capture ~r/(.+?)(:|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A)/mi
+      @protocol_separator ":|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A"
+      @protocol_separator_regex Regex.compile!(@protocol_separator, "mi")
+
+      @http_like_scheme "(?<scheme>.+?)(#{@protocol_separator})//"
+      @other_schemes "(?<other_schemes>mailto)(#{@protocol_separator})"
+
+      @scheme_capture Regex.compile!("(#{@http_like_scheme})|(#{@other_schemes})", "mi")
 
       def scrub_attribute(unquote(tag_name), {unquote(attr_name), uri}) do
-        valid_schema = if String.match?(uri, @protocol_separator) do
-          case Regex.run(@scheme_capture, uri) do
-            [_, scheme, _] ->
-              Enum.any?(unquote(valid_schemes), fn x -> x == scheme end)
-            nil ->
+        valid_schema = if uri =~ @protocol_separator_regex do
+          @scheme_capture
+          |> Regex.named_captures(uri)
+          |> case do
+            %{"scheme" => scheme, "other_schemes" => ""} ->
+              scheme in unquote(valid_schemes)
+            %{"other_schemes" => scheme, "scheme" => ""} ->
+              scheme in unquote(valid_schemes)
+            _ ->
               false
           end
         else

--- a/test/basic_html_test.exs
+++ b/test/basic_html_test.exs
@@ -340,6 +340,11 @@ defmodule HtmlSanitizeExScrubberBasicHTMLTest do
     assert input == basic_html_sanitize(input)
   end
 
+  test "should_not_crash_on_invalid_schema_formatting" do
+    input = "<a href=\"http//www.domain.com/?encoded_param=param1%3Aparam2\">text here</a>"
+    assert "<a>text here</a>" == basic_html_sanitize(input)
+  end
+
   test "should_sanitize_neverending_attribute" do
     assert "<span></span>" == basic_html_sanitize("<span class=\"\\")
   end


### PR DESCRIPTION
I've experienced `case` expression crash (`%CaseClauseError{}`) on sanitizing invalid URIs which contain protocol separator(`:`) but in the URI itself and not on the position of schema separator. Example of such URI is included in tests. 