### PR TITLE
List attributes for img correctly

### DIFF
--- a/lib/html_sanitize_ex/scrubber/html5.ex
+++ b/lib/html_sanitize_ex/scrubber/html5.ex
@@ -594,7 +594,12 @@ defmodule HtmlSanitizeEx.Scrubber.HTML5 do
     "tabindex",
     "title",
     "translate",
-    "alt crossorigin usemap ismap width height"
+    "alt",
+    "crossorigin",
+    "usemap",
+    "ismap",
+    "width",
+    "height"
   ])
 
   Meta.allow_tag_with_uri_attributes("input", ["src"], @valid_schemes)


### PR DESCRIPTION
First of all, thanks for maintaining this project! 

I think I found a bug, though I am not certain it wasn't intentional. If it's not a bug, let me know, and I'll close this. 

## What changed?

Looking at the HTML5 module, it seems that the [last few attributes](https://github.com/rrrene/html_sanitize_ex/blob/master/lib/html_sanitize_ex/scrubber/html5.ex#L575-L597) were not set correctly. So `img` tags were getting these attributes stripped: `alt`, `crossorigin`, `usemap`, `ismap`, `width`, and `height`.

I would also be happy to add a test if you'd like. But looking at the `html5_test.exs` file, I didn't see specific tests for each attribute, so I didn't want to introduce tests you wouldn't want to keep. 