### PR TITLE
Add sizes attribute to the list supported attributes of img tag

### DIFF
--- a/lib/html_sanitize_ex/scrubber/html5.ex
+++ b/lib/html_sanitize_ex/scrubber/html5.ex
@@ -704,7 +704,8 @@ defmodule HtmlSanitizeEx.Scrubber.HTML5 do
     "usemap",
     "ismap",
     "width",
-    "height"
+    "height",
+    "size"
   ])
 
   Meta.allow_tag_with_uri_attributes("input", ["src"], @valid_schemes)

--- a/lib/html_sanitize_ex/scrubber/html5.ex
+++ b/lib/html_sanitize_ex/scrubber/html5.ex
@@ -705,7 +705,7 @@ defmodule HtmlSanitizeEx.Scrubber.HTML5 do
     "ismap",
     "width",
     "height",
-    "size"
+    "sizes"
   ])
 
   Meta.allow_tag_with_uri_attributes("input", ["src"], @valid_schemes)

--- a/test/html5_test.exs
+++ b/test/html5_test.exs
@@ -105,6 +105,13 @@ defmodule HtmlSanitizeExScrubberHTML5Test do
     assert input == full_html_sanitize(input)
   end
 
+  test "does not strip valid html5 attributes srcset and sizes from <img>" do
+    input =
+      ~s[<img src="http://abcd.com" srcset="elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w" sizes="(max-width: 600px) 480px, 800px" />]
+
+    assert input == full_html_sanitize(input)
+  end
+
   test "does not strip any header tags" do
     input = """
     <h1>Header 1</h1>


### PR DESCRIPTION
- Add the `sizes` attribute to the list of supported attributes of the `img` tag.
- Add test for the `sizes` attribute.

Reference: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images