### PR TITLE
inline regex into functions body

### DIFF
--- a/lib/html_sanitize_ex/scrubber/meta.ex
+++ b/lib/html_sanitize_ex/scrubber/meta.ex
@@ -122,7 +122,9 @@ defmodule HtmlSanitizeEx.Scrubber.Meta do
   """
   defmacro allow_tags_with_style_attributes(list) do
     list
-    |> Enum.map(fn tag_name -> allow_this_tag_with_style_attribute(tag_name) end)
+    |> Enum.map(fn tag_name ->
+      allow_this_tag_with_style_attribute(tag_name)
+    end)
   end
 
   @doc """
@@ -214,23 +216,17 @@ defmodule HtmlSanitizeEx.Scrubber.Meta do
       end
 
       @protocol_separator ":|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A"
-      @protocol_separator_regex Regex.compile!(@protocol_separator, "mi")
 
       @http_like_scheme "(?<scheme>.+?)(#{@protocol_separator})//"
       @other_schemes "(?<other_schemes>mailto)(#{@protocol_separator})"
-
-      @scheme_capture Regex.compile!(
-                        "(#{@http_like_scheme})|(#{@other_schemes})",
-                        "mi"
-                      )
 
       @max_scheme_length 20
 
       def scrub_attribute(unquote(tag_name), {unquote(attr_name), uri}) do
         valid_schema =
-          if uri =~ @protocol_separator_regex do
+          if uri =~ ~r/#{@protocol_separator}/mi do
             case Regex.named_captures(
-                   @scheme_capture,
+                   ~r/(#{@http_like_scheme})|(#{@other_schemes})/mi,
                    uri |> String.slice(0..@max_scheme_length)
                  ) do
               %{"scheme" => scheme, "other_schemes" => ""} ->


### PR DESCRIPTION
Starting with Elixir 1.19, regexes in module attributes are deprecated and emit
a warning (see https://github.com/elixir-lang/elixir/pull/14381). This is due to
a change in how OTP handles regexes, in upcoming version 28.

This PR tries to adress the warning generated by regex in module attributes.
Unfortunately, I was not able to compile the projet locally, I got an error
trying to compile `:mochiweb` :confused: So, local tests were really incomplete,
sorry for that :sweat_smile:
