### PR TITLE
Update mochi to allow otp 27+ upgrades

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule HtmlSanitizeEx.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:mochiweb, "~> 2.15 or ~> 3.1"},
+      {:mochiweb, "~> 2.15 or ~> 3.2"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
While trying to update my project to use OTP 27, i've hit and issue with mochi.

This just allow us to use the newest version of mochi, which avoid this problems.

Removes the need of using override and hard dependency to our `mix.exs` file