### PR TITLE
Fix redundant `scrub_attributes/2` clauses on Elixir 1.20

### DIFF
--- a/lib/html_sanitize_ex.ex
+++ b/lib/html_sanitize_ex.ex
@@ -34,12 +34,6 @@ defmodule HtmlSanitizeEx do
       remove_cdata_sections_before_scrub()
       strip_comments()
 
-      def scrub_attributes(tag, attributes) do
-        attributes
-        |> Enum.map(&scrub_attribute(tag, &1))
-        |> Enum.reject(&is_nil(&1))
-      end
-
       defoverridable HtmlSanitizeEx.Scrubber
 
       unquote(extend(opts[:extend]))

--- a/lib/html_sanitize_ex/scrubber_compiler.ex
+++ b/lib/html_sanitize_ex/scrubber_compiler.ex
@@ -24,7 +24,19 @@ defmodule HtmlSanitizeEx.ScrubberCompiler do
 
       unquote(quote_allowed_tag_name_scrubs(allowed_tag_names))
 
+      unquote(quote_default_scrub_attributes_catchall())
+
       unquote(fallback_or_strip_everything)
+    end
+  end
+
+  defp quote_default_scrub_attributes_catchall do
+    quote do
+      def scrub_attributes(tag, attributes) do
+        attributes
+        |> Enum.map(&scrub_attribute(tag, &1))
+        |> Enum.reject(&is_nil(&1))
+      end
     end
   end
 
@@ -71,13 +83,6 @@ defmodule HtmlSanitizeEx.ScrubberCompiler do
       quote do
         def scrub({unquote(tag_name), attributes, children}) do
           {unquote(tag_name), scrub_attributes(unquote(tag_name), attributes), children}
-        end
-
-        def scrub_attributes(unquote(tag_name), attributes) do
-          Enum.map(attributes, fn attr ->
-            scrub_attribute(unquote(tag_name), attr)
-          end)
-          |> Enum.reject(&is_nil(&1))
         end
       end
     end)

--- a/test/html_sanitize_ex/scrubber/extend/per_tag_override_test.exs
+++ b/test/html_sanitize_ex/scrubber/extend/per_tag_override_test.exs
@@ -1,0 +1,25 @@
+defmodule PerTagOverrideTest do
+  use ExUnit.Case, async: true
+
+  defmodule TagOverrideScrubber do
+    use HtmlSanitizeEx, extend: :basic_html
+
+    allow_tag_with_these_attributes("p", ["class"])
+
+    def scrub_attributes("p", _attributes), do: []
+  end
+
+  test "per-tag override of scrub_attributes/2 takes precedence over the default catch-all" do
+    assert TagOverrideScrubber.sanitize(~s(<p class="foo">hi</p>)) == "<p>hi</p>"
+  end
+
+  test "direct call to overridden scrub_attributes/2 returns the override result" do
+    assert TagOverrideScrubber.scrub_attributes("p", [{"class", "foo"}]) == []
+  end
+
+  test "non-overridden tags still use the default catch-all" do
+    assert TagOverrideScrubber.scrub_attributes("a", [{"href", "https://example.com"}]) == [
+             {"href", "https://example.com"}
+           ]
+  end
+end


### PR DESCRIPTION
Elixir 1.20's type checker flags every per-tag `scrub_attributes/2` clause as redundant because the generic catch-all emitted in `__using__` already matches `term(), term()` and shadows them.

Move the catch-all to the end of `__before_compile__` so per-tag specific clauses match first, and drop the now-redundant per-tag `scrub_attributes/2` emission from `quote_allowed_tag_name_scrubs/1` (its body is identical to the catch-all).

This also fixes a latent bug: user `def scrub_attributes("<tag>", _)` overrides were silently shadowed by the `__using__` catch-all pre-fix; they now take precedence.