### PR TITLE
CSS scrubber: add justify keyword

### DIFF
--- a/lib/html_sanitize_ex/scrubber/css.ex
+++ b/lib/html_sanitize_ex/scrubber/css.ex
@@ -179,6 +179,7 @@ defmodule HtmlSanitizeEx.Scrubber.CSS do
     "green",
     "!important",
     "italic",
+    "justify",
     "left",
     "lime",
     "maroon",

--- a/test/html_sanitize_ex/scrubber/css_test.exs
+++ b/test/html_sanitize_ex/scrubber/css_test.exs
@@ -8,6 +8,7 @@ defmodule HtmlSanitizeExScrubberCSSTest do
   @good_css [
     ".test { color: red; border: 1px solid brown; }",
     "div.foo { width: 500px; height: 200px; }",
+    "p.justified { text-align: justify; }",
     # gibberish should work
     "GI b gkljfl kj { { { ********"
   ]


### PR DESCRIPTION
Our team has been maintaining a fork of `html_sanitize_ex` for the past year, mainly to allow the CSS srubber to leave `text-align: justify` unscrubbed ([text-align values](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-align)). 

I noticed that since our fork, this repository has been active again, so here is a PR that adds `justify` to the CSS scrubber allowed keywords + a corresponding test case.

**Note** : I didn't go further to allow all other valid `text-align` values (as I didn't notice this pattern on the other CSS attributes), let me know if you would like me to.