### PR TITLE
Escape dangling processing instruction marker to avoid parser crash

### DIFF
--- a/lib/html_sanitize_ex/parser.ex
+++ b/lib/html_sanitize_ex/parser.ex
@@ -29,6 +29,7 @@ defmodule HtmlSanitizeEx.Parser do
 
   defp before_parse(html) do
     html
+    |> String.replace("<?", "&lt;?")
     |> String.replace(~r/(>)(\r?\n)/, "\\1 #{@replacement_linebreak} \\2")
     |> String.replace(~r/(>)(\ +)(<)/, "\\1 #{@replacement_space}\\2\\3")
     |> String.replace(~r/(>)(\t+)(<)/, "\\1 #{@replacement_tab}\\2\\3")

--- a/test/html_sanitize_ex/scrubber/basic_html_test.exs
+++ b/test/html_sanitize_ex/scrubber/basic_html_test.exs
@@ -373,6 +373,10 @@ defmodule HtmlSanitizeExScrubberBasicHTMLTest do
     assert "<span></span>" == basic_html_sanitize("<span class=\"\\")
   end
 
+  test "should_not_crash_on_dangling_processing_instruction" do
+    assert "hello&lt;?" == basic_html_sanitize("hello<?")
+  end
+
   # test "this affects only NS4, but we're on a roll, right?" do
   #  input = "<div size=\"&{alert('XSS')}\">foo</div>"
   #  expected = "<div>foo</div>"


### PR DESCRIPTION
Closes #81. Any input containing a `<?` sequence (e.g. `hello<?` or `<?xml`) makes mochiweb raise a CaseClauseError out of `find_qgt/2`, so `basic_html/1` and the other scrubbers blow up instead of sanitizing.

I added a `String.replace("<?", "&lt;?")` to `before_parse/1` so the marker is treated as plain text, which keeps the rest of the document sanitization intact. Added a regression test in basic_html_test.exs alongside the existing should_not_crash cases.